### PR TITLE
orchestrator: initial "Action" support. Currently, only "Accept" action is supported.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 bin/
 
 .idea
+*.iml

--- a/libearthquake/equtils/common.go
+++ b/libearthquake/equtils/common.go
@@ -47,10 +47,17 @@ type Event struct {
 
 	ProcId string
 
-	EventType  string
+	EventType  string // e.g., "FuncCall", "_REST" ("_REST" not supported yet)
 	EventParam string
 
 	JavaSpecific *Event_JavaSpecific
+}
+
+type Action struct {
+	ActionType  string // e.g., "Accept", "_REST" (_"REST" not supported yet)
+	ActionParam string
+
+	Evt *Event
 }
 
 type SingleTrace struct {

--- a/libearthquake/explorepolicy/bfs/bfs.go
+++ b/libearthquake/explorepolicy/bfs/bfs.go
@@ -29,7 +29,7 @@ type BFSParam struct {
 }
 
 type BFS struct {
-	nextEventChan chan *Event
+	nextActionChan chan *Action
 	randGen       *rand.Rand
 	queueMutex    *sync.Mutex
 
@@ -90,7 +90,8 @@ func (this *BFS) Init(storage HistoryStorage, param map[string]interface{}) {
 
 				go func() {
 					for _, e := range evQ {
-						this.nextEventChan <- e
+						act := Action{ActionType: "Accept", Evt: e}
+						this.nextActionChan <- &act
 					}
 				}()
 
@@ -105,7 +106,8 @@ func (this *BFS) Init(storage HistoryStorage, param map[string]interface{}) {
 
 			prefix = append(prefix, *next)
 
-			this.nextEventChan <- next
+			act := Action{ActionType: "Accept", Evt: next}
+			this.nextActionChan <- &act
 		}
 	}()
 }
@@ -114,8 +116,8 @@ func (this *BFS) Name() string {
 	return "BFS"
 }
 
-func (this *BFS) GetNextEventChan() chan *Event {
-	return this.nextEventChan
+func (this *BFS) GetNextActionChan() chan *Action {
+	return this.nextActionChan
 }
 
 func (this *BFS) QueueNextEvent(procId string, ev *Event) {
@@ -125,7 +127,8 @@ func (this *BFS) QueueNextEvent(procId string, ev *Event) {
 		this.eventQueue = append(this.eventQueue, ev)
 	} else {
 		go func() {
-			this.nextEventChan <- ev
+			act := Action{ActionType: "Accept", Evt: ev}
+			this.nextActionChan <- &act
 		}()
 	}
 
@@ -133,13 +136,13 @@ func (this *BFS) QueueNextEvent(procId string, ev *Event) {
 }
 
 func BFSNew() *BFS {
-	nextEventChan := make(chan *Event)
+	nextActionChan := make(chan *Action)
 	eventQueue := make([]*Event, 0)
 	mutex := new(sync.Mutex)
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	return &BFS{
-		nextEventChan,
+		nextActionChan,
 		r,
 		mutex,
 		eventQueue,

--- a/libearthquake/explorepolicy/dpor/dpor.go
+++ b/libearthquake/explorepolicy/dpor/dpor.go
@@ -30,7 +30,7 @@ type DPORParam struct {
 }
 
 type DPOR struct {
-	nextEventChan chan *Event
+	nextActionChan chan *Action
 	randGen       *rand.Rand
 	queueMutex    *sync.Mutex
 
@@ -129,7 +129,8 @@ func (this *DPOR) Init(storage HistoryStorage, param map[string]interface{}) {
 
 			prefix = append(prefix, *next)
 
-			this.nextEventChan <- next
+			act := Action{ActionType: "Accept", Evt: next}
+			this.nextActionChan <- &act
 		}
 	}()
 }
@@ -138,8 +139,8 @@ func (this *DPOR) Name() string {
 	return "DPOR"
 }
 
-func (this *DPOR) GetNextEventChan() chan *Event {
-	return this.nextEventChan
+func (this *DPOR) GetNextActionChan() chan *Action {
+	return this.nextActionChan
 }
 
 func (this *DPOR) QueueNextEvent(procId string, ev *Event) {
@@ -151,13 +152,13 @@ func (this *DPOR) QueueNextEvent(procId string, ev *Event) {
 }
 
 func DPORNew() *DPOR {
-	nextEventChan := make(chan *Event)
+	nextActionChan := make(chan *Action)
 	eventQueue := make([]*Event, 0)
 	mutex := new(sync.Mutex)
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	return &DPOR{
-		nextEventChan,
+		nextActionChan,
 		r,
 		mutex,
 		eventQueue,

--- a/libearthquake/explorepolicy/dumb/dumbpolicy.go
+++ b/libearthquake/explorepolicy/dumb/dumbpolicy.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Dumb struct {
-	nextEventChan chan *Event
+	nextActionChan chan *Action
 }
 
 func (d *Dumb) Init(storage HistoryStorage, param map[string]interface{}) {
@@ -31,20 +31,21 @@ func (d *Dumb) Name() string {
 	return "dumb"
 }
 
-func (d *Dumb) GetNextEventChan() chan *Event {
-	return d.nextEventChan
+func (d *Dumb) GetNextActionChan() chan *Action {
+	return d.nextActionChan
 }
 
 func (d *Dumb) QueueNextEvent(id string, ev *Event) {
 	go func(e *Event) {
-		d.nextEventChan <- ev
+		act := Action{ActionType: "Accept", Evt: ev}
+		d.nextActionChan <- &act
 	}(ev)
 }
 
 func DumbNew() *Dumb {
-	nextEventChan := make(chan *Event)
+	nextActionChan := make(chan *Action)
 
 	return &Dumb{
-		nextEventChan,
+		nextActionChan,
 	}
 }

--- a/libearthquake/explorepolicy/explorepolicy.go
+++ b/libearthquake/explorepolicy/explorepolicy.go
@@ -34,7 +34,7 @@ type ExplorePolicy interface {
 	Init(storage historystorage.HistoryStorage, param map[string]interface{})
 	Name() string
 
-	GetNextEventChan() chan *Event
+	GetNextActionChan() chan *Action
 	QueueNextEvent(id string, ev *Event)
 }
 

--- a/libearthquake/explorepolicy/random/randompolicy.go
+++ b/libearthquake/explorepolicy/random/randompolicy.go
@@ -30,7 +30,7 @@ type RandomParam struct {
 }
 
 type Random struct {
-	nextEventChan chan *Event
+	nextActionChan chan *Action
 	randGen       *rand.Rand
 	queueMutex    *sync.Mutex
 
@@ -87,7 +87,8 @@ func (r *Random) Init(storage HistoryStorage, param map[string]interface{}) {
 
 			r.queueMutex.Unlock()
 
-			r.nextEventChan <- next
+			act := Action{ActionType: "Accept", Evt: next}
+			r.nextActionChan <- &act
 		}
 	}()
 }
@@ -96,8 +97,8 @@ func (r *Random) Name() string {
 	return "random"
 }
 
-func (r *Random) GetNextEventChan() chan *Event {
-	return r.nextEventChan
+func (r *Random) GetNextActionChan() chan *Action {
+	return r.nextActionChan
 }
 
 func (r *Random) QueueNextEvent(procId string, ev *Event) {
@@ -113,14 +114,14 @@ func (r *Random) QueueNextEvent(procId string, ev *Event) {
 }
 
 func RandomNew() *Random {
-	nextEventChan := make(chan *Event)
+	nextActionChan := make(chan *Action)
 	highEventQueue := make([]*Event, 0)
 	lowEventQueue := make([]*Event, 0)
 	mutex := new(sync.Mutex)
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	return &Random{
-		nextEventChan,
+		nextActionChan,
 		r,
 		mutex,
 		highEventQueue,

--- a/libearthquake/explorepolicy/zk2172/zk2172.go
+++ b/libearthquake/explorepolicy/zk2172/zk2172.go
@@ -38,7 +38,7 @@ type zkEvent struct {
 }
 
 type ZK2172 struct {
-	nextEventChan chan *Event
+	nextActionChan chan *Action
 	randGen       *rand.Rand
 	queueMutex    *sync.Mutex
 
@@ -107,7 +107,8 @@ func (this *ZK2172) Init(storage HistoryStorage, param map[string]interface{}) {
 			this.queueMutex.Unlock()
 
 			if nextEvent != nil {
-				this.nextEventChan <- nextEvent
+				act := Action{ActionType: "Accept", Evt: nextEvent}
+				this.nextActionChan <- &act
 			}
 		}
 	}()
@@ -117,8 +118,8 @@ func (this *ZK2172) Name() string {
 	return "ZK2172"
 }
 
-func (this *ZK2172) GetNextEventChan() chan *Event {
-	return this.nextEventChan
+func (this *ZK2172) GetNextActionChan() chan *Action {
+	return this.nextActionChan
 }
 
 func (this *ZK2172) QueueNextEvent(procId string, ev *Event) {
@@ -138,13 +139,13 @@ func (this *ZK2172) QueueNextEvent(procId string, ev *Event) {
 }
 
 func ZK2172New() *ZK2172 {
-	nextEventChan := make(chan *Event)
+	nextActionChan := make(chan *Action)
 	eventQueue := make([]*zkEvent, 0)
 	mutex := new(sync.Mutex)
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	return &ZK2172{
-		nextEventChan,
+		nextActionChan,
 		r,
 		mutex,
 		eventQueue,


### PR DESCRIPTION
I'm going to add "_REST" event/action for current REST-based ethernet inspector
    
Other possible actions:
 * "Drop" (mainly for ethernet inspector)
 * "RaiseException(param={klazz: "FooBarException"}"
 *  "CrashDisk(param={vfs: "/mnt/foobar"})
...
    
 TODO: dump action sequence rather than event sequence in dump-trace.
