### PR TITLE
example/zk-repro-2080.nfqhook: fix some issues

### DIFF
--- a/example/zk-repro-2080.nfqhook/README.md
+++ b/example/zk-repro-2080.nfqhook/README.md
@@ -3,13 +3,14 @@
 
 ## How to Reproduce the Bug with Earthquake
    
-NOTE: this test scenario is under work-in-progress. (Only `FLE.Initial` can be inspected at the moment)
+NOTE: this test scenario is under work-in-progress. reproduction probability is still not so high.
    
 ### Start Earthquake
 Please see [../../doc/how-to-setup-env.md](../../doc/how-to-setup-env.md) for how to setup the environment.
 
 
 	$ sudo pip install pip install git+https://github.com/twitter/zktraffic@68d9f85d8508e01f5d2f6657666c04e444e6423c  #(Jul 18, 2015)
+	$ sudo sh -c 'echo 0 > /proc/sys/net/ipv4/tcp_autocorking' # required if you are using Linux 3.14 or later
 	$ sudo useradd --foo-bar nfqhooked
 	$ sudo iptables -A OUTPUT -p tcp -m owner --uid-owner $(id -u nfqhooked) -j NFQUEUE --queue-num 42
     $ sudo PYTHONPATH=$(pwd)/../.. ../../bin/earthquake init --force config.toml materials /tmp/zk-2080

--- a/example/zk-repro-2080.nfqhook/config.toml
+++ b/example/zk-repro-2080.nfqhook/config.toml
@@ -3,11 +3,13 @@ run = "run.sh"
 validate = "validate.sh"
 clean = "clean.sh"
 
-
-# storageType = "mongodb"
+storageType = "mongodb"
 
 explorePolicy = "random"
+
 [explorePolicyParam]
-  interval = 10
-  timeBound = true
-  maxBound = 100
+  interval = 180
+  timeBound = false
+
+## interval=180, 200, 300 seems reproductive, but too long interval?
+## interval<=150 seems not reproductive?

--- a/example/zk-repro-2080.nfqhook/materials/lib.sh
+++ b/example/zk-repro-2080.nfqhook/materials/lib.sh
@@ -37,8 +37,12 @@ function CHECK_PREREQUISITES() {
     hash ant
     INFO "Checking whether zktraffic is installed"
     python -c "from zktraffic.omni.omni_sniffer import OmniSniffer"
+    if [ -f /proc/sys/net/ipv4/tcp_autocorking ]; then
+	INFO "Checking whether tcp_autocorking (introduced in Linux 3.14) is disabled"
+	test $(cat /proc/sys/net/ipv4/tcp_autocorking) = 0
+    fi
     INFO "Checking existence of user \"nfqhooked\""
-    id -u nfqhooked    
+    id -u nfqhooked
     if [ -z $EQ_DISABLE ]; then
 	INFO "Checking whether NFQUEUE 42 is configured for a user \"nfqhooked\""
 	iptables -n -L -v | grep "owner UID match $(id -u nfqhooked) NFQUEUE num 42"

--- a/example/zk-repro-2080.nfqhook/materials/zk_inspector.py
+++ b/example/zk-repro-2080.nfqhook/materials/zk_inspector.py
@@ -10,7 +10,9 @@ LOG = pyearthquake.LOG.getChild(__name__)
 class Zk2080Inspector(ZkEtherInspector):
 
     def __init__(self, zmq_addr):
-        super(Zk2080Inspector, self).__init__(zmq_addr, ignore_pings=False)
+        super(Zk2080Inspector, self).__init__(zmq_addr,
+                                              ignore_pings=True,
+                                              dump_bad_packet=False)
 
 if __name__ == '__main__':
     d = Zk2080Inspector(zmq_addr=ZMQ_ADDR)

--- a/pyearthquake/middlebox/nfqhook.py
+++ b/pyearthquake/middlebox/nfqhook.py
@@ -4,7 +4,6 @@ import sys
 import eventlet
 
 from eventlet.green import socket
-import scapy.all
 
 from .. import LOG as _LOG
 from pyearthquake.middlebox.internal.nfq import NFQ
@@ -77,5 +76,11 @@ class NFQHook(object):
 
     def send_ip_packet_to_inspector(self, packet_id, ip_bytes):
         LOG.debug('Sending packet %d to inspector', packet_id)
-        dummy_eth = scapy.all.Ether() / scapy.all.IP(ip_bytes)
-        self.zmq_client.send(packet_id, str(dummy_eth))
+
+        # from hexdump import hexdump
+        # for l in hexdump(ip_bytes, result='generator'):
+        #     LOG.debug(l)
+
+        # TODO: eliminate dummy eth header
+        dummy_eth = '\xff\xff\xff\xff\xff\xff' + '\x00\x00\x00\x00\x00\x00' + '\x08\x00' + ip_bytes
+        self.zmq_client.send(packet_id, dummy_eth)


### PR DESCRIPTION
This reproduces ZK-2080 when config.explorePolicy.interval is about 180-200.
However I could not reproduce the bug when interval <= 150.

NOTE: I had once reproduced the bug with pyearthquake orchestrator with DumbExplorer(sleep=30)