### PR TITLE
earthquake-container(eqc): initial commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM osrg/dind-ovs-ryu
 MAINTAINER Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ## Install Earthquake deps (protoc, JDK)
-    protobuf-compiler default-jdk maven \
-    ## Install useful stuffs
+    ## Install Earthquake deps
+    protobuf-compiler pkg-config libzmq3-dev libnetfilter-queue-dev \
+    ## (Optional) Install Java inspector deps
+    default-jdk maven \
+    ## (Optional) Install useful stuffs
     sudo ant ant-optional \
     ## (Optional) Install MongoDB storage
     mongodb \

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
-# Earthquake: Dynamic Model Checker for Distributed Systems
+# Earthquake: Programmable Fuzzy Scheduler for Testing Distributed Systems
 
 [![Release](http://github-release-version.herokuapp.com/github/osrg/earthquake/release.svg?style=flat)](https://github.com/osrg/earthquake/releases/latest)
 [![Join the chat at https://gitter.im/osrg/earthquake](https://img.shields.io/badge/GITTER-join%20chat-green.svg)](https://gitter.im/osrg/earthquake?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![GoDoc](https://godoc.org/github.com/osrg/earthquake/earthquake?status.svg)](https://godoc.org/github.com/osrg/earthquake/earthquake)
 [![Build Status](https://travis-ci.org/osrg/earthquake.svg?branch=master)](https://travis-ci.org/osrg/earthquake)
 
-Earthquake is a dynamic model checker (DMCK) for real implementations of distributed system (such as ZooKeeper).
+Earthquake is a programmable fuzzy scheduler for testing real implementations of distributed system (such as ZooKeeper).
 
 Blog: [http://osrg.github.io/earthquake/](http://osrg.github.io/earthquake/)
 
 Earthquakes permutes C/Java function calls, Ethernet packets, Filesystem events, and injected faults in various orders so as to find implementation-level bugs of the distributed system.
-When Earthquake finds a bug, Earthquake automatically records [the event history](example/zk-found-2212.ryu) and helps you to analyze which permutation of events triggers the bug.
+When Earthquake finds a bug, Earthquake automatically records [the event history](http://osrg.github.io/earthquake/post/zookeeper-2212/) and helps you to analyze which permutation of events triggers the bug.
+Earthquake also collects [branch patterns](http://osrg.github.io/earthquake/post/zookeeper-2080/) for deeper analysis.
 
-Basically, Earthquake permutes events in a random order, but you can write your [own state exploration policy](doc/arch.md) (in Go or Python) for finding deep bugs efficiently.
+Basically, Earthquake permutes events in a random order, but you can write your [own state exploration policy](doc/arch.md) (in Golang) for finding deep bugs efficiently.
 
 ## Found/Reproduced Bugs
  * ZooKeeper:
   * Found [ZOOKEEPER-2212](https://issues.apache.org/jira/browse/ZOOKEEPER-2212) (race): [blog article](http://osrg.github.io/earthquake/post/zookeeper-2212/) ([repro code](example/zk-found-2212.ryu))
   * Reproduced [ZOOKEEPER-2080](https://issues.apache.org/jira/browse/ZOOKEEPER-2080) (race): [blog article](http://osrg.github.io/earthquake/post/zookeeper-2080/) ([repro code](example/zk-repro-2080.nfqhook))
+  * Reproduced [ZOOKEEPER-2251](https://issues.apache.org/jira/browse/ZOOKEEPER-2251) (race): ([repro code](example/zk-repro-2251.nfqhook))
  * etcd:
   * Found an etcd command line client (etcdctl) bug [#3517](https://github.com/coreos/etcd/issues/3517) (timing specification), fixed in [#3530](https://github.com/coreos/etcd/pull/3530): ([repro code](example/etcd/3517-reproduce)). The fix also resulted a hint of [#3611](https://github.com/coreos/etcd/pull/3611).
  * YARN:
@@ -45,6 +47,7 @@ Released under [Apache License 2.0](LICENSE).
 
 ## API Overview
 ```go
+// implements earthquake/explorepolicy/ExplorePolicy interface
 type MyPolicy struct {
 	actionCh chan Action
 }
@@ -69,6 +72,8 @@ func (p *MyPolicy) QueueNextEvent(event Event) {
 		panic(err)
 	}
 	// send in a goroutine so as to make the function non-blocking.
+	// (Note that earthquake/util/queue/TimeBoundedQueue provides
+	// better semantics and determinism, this is just an example.)
 	go func() {
 		fmt.Printf("Action ready: %s\n", action)
 		p.actionCh <- action

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Basically, Earthquake permutes events in a random order, but you can write your 
   * Found [YARN-4301](https://issues.apache.org/jira/browse/YARN-4301) (fault tolerance): ([repro code](example/yarn/4301-reproduce))
 
 ## Quick Start
+
+    $ go get github.com/osrg/earthquake/earthquake-container
+    $ sudo earthquake-container run -it --rm --eq-config config.toml ubuntu bash
+
  * How to set up the environment: [GettingStarted](http://osrg.github.io/earthquake/gettingStarted/) ([some extra info](doc/how-to-setup-env.md))
  * Example: Finding a distributed race condition bug of ZooKeeper([ZOOKEEPER-2212](https://issues.apache.org/jira/browse/ZOOKEEPER-2212)): [blog article](http://osrg.github.io/earthquake/post/zookeeper-2212/) ([repro code](example/zk-found-2212.ryu))
 

--- a/build
+++ b/build
@@ -27,22 +27,24 @@ protoc --go_out=earthquake/util/pb -Iinspector inspector/inspector_message.proto
 ########## Go ##########
 INFO "Fetching Earthquake deps"
 go get -t github.com/osrg/earthquake/earthquake
+go get -t github.com/osrg/earthquake/earthquake-container
+go get -t github.com/stretchr/testify/assert
 
-INFO "Building Earthquake (bin/earthquake)"
-go build -o bin/earthquake github.com/osrg/earthquake/earthquake
-
+for f in earthquake earthquake-container; do
+    INFO "Building $f"
+    go build -o bin/$f github.com/osrg/earthquake/$f
 (
-    cd earthquake
-    INFO "Testing Earthquake"
-    go get -t github.com/stretchr/testify/assert
+    cd $f
+    INFO "Testing $f"
     go test ./...
 
-    INFO "Running \`go vet\` for  Earthquake"
+    INFO "Running \`go vet\` for $f"
     go vet ./...
 
-    INFO "Running \`go fmt\` for Earthquake"
+    INFO "Running \`go fmt\` for $f"
     go fmt ./...
 )
+done
 
 EXAMPLES="example/template/mypolicy.go example/yarn/4301-reproduce/mypolicy.go"
 for f in $EXAMPLES; do

--- a/doc/how-to-setup-env-full.md
+++ b/doc/how-to-setup-env-full.md
@@ -1,0 +1,23 @@
+# How to setup the environment for Earthquake (Full stack)
+
+All you have to do is make Docker installed on your host and run the pre-built Docker image [osrg/earthquake](https://registry.hub.docker.com/u/osrg/earthquake/).
+
+[![Docker Hub](http://dockeri.co/image/osrg/earthquake)](https://registry.hub.docker.com/u/osrg/earthquake/)
+
+    
+    $ sudo modprobe openvswitch
+    $ docker run --rm --tty --interactive --privileged -e EQ_DOCKER_PRIVILEGED=1 osrg/earthquake 
+    INIT: Running with privileged mode. Enabling DinD, OVS, and Ryu
+    INIT: Earthquake is installed on /earthquake. Please refer to /earthquake/README.md
+    INIT: Starting command: ['wrapdocker', '/init.dind-ovs-ryu.sh']
+    * /etc/openvswitch/conf.db does not exist
+    * Creating empty database /etc/openvswitch/conf.db
+    * Starting ovsdb-server
+    * Configuring Open vSwitch system IDs
+    * Starting ovs-vswitchd
+    * Enabling remote OVSDB managers
+    Assigned 192.168.42.254 to ovsbr0
+    root@907529be8b21:/earthquake# 
+
+Then, you can do the things what you want in `/earthquake` directory.
+You might want to try several [examples](../example).

--- a/doc/how-to-setup-env.md
+++ b/doc/how-to-setup-env.md
@@ -1,100 +1,19 @@
-# How to setup the environment for Earthquake
-
-All you have to do is make Docker installed on your host and run the pre-built Docker image [osrg/earthquake](https://registry.hub.docker.com/u/osrg/earthquake/).
-
-[![Docker Hub](http://dockeri.co/image/osrg/earthquake)](https://registry.hub.docker.com/u/osrg/earthquake/)
-
-    
-    $ docker run --rm --tty --interactive osrg/earthquake
-    INIT: Running without privileged mode. Please set EQ_DOCKER_PRIVILEGED if you want to use Ethernet Inspector
-    INIT: Earthquake is installed on /earthquake. Please refer to /earthquake/README.md
-    INIT: Starting command: ['/bin/bash', '--login', '-i']
-    root@a0c2e4413483:/earthquake# ^D
-    INIT: Exiting with status 0..(['/bin/bash', '--login', '-i'])
-	
-Then, you can do the things what you want in `/earthquake` directory.
-You might want to try several [examples](../example).
+# How to setup the environment for Earthquake Container (simplified CLI)
+For full-stack environment, please refer to [how-to-setup-env-full.md](how-to-setup-env-full.md).
 
 
-## Privileged Mode (provides Docker-in-Docker, Open vSwitch, and Ryu)
-This mode might be useful for Ethernet Inspector.
-    
-    $ sudo modprobe openvswitch
-    $ docker run --rm --tty --interactive --privileged -e EQ_DOCKER_PRIVILEGED=1 osrg/earthquake 
-    INIT: Running with privileged mode. Enabling DinD, OVS, and Ryu
-    INIT: Earthquake is installed on /earthquake. Please refer to /earthquake/README.md
-    INIT: Starting command: ['wrapdocker', '/init.dind-ovs-ryu.sh']
-    * /etc/openvswitch/conf.db does not exist
-    * Creating empty database /etc/openvswitch/conf.db
-    * Starting ovsdb-server
-    * Configuring Open vSwitch system IDs
-    * Starting ovs-vswitchd
-    * Enabling remote OVSDB managers
-    Assigned 192.168.42.254 to ovsbr0
-    root@907529be8b21:/earthquake# ^D
-    INIT: Exiting with status 0..(['wrapdocker', '/init.dind-ovs-ryu.sh'])
-    
+    $ sudo apt-get install libzmq3-dev libnetfilter-queue-dev
+    $ go get github.com/osrg/earthquake/earthquake-container
+    $ sudo earthquake-container run -it --rm --eq-config config.toml ubuntu bash
 
-## Set up the environment manually (You might NOT need to read this section)
-If you want to set up your own environment manually, please follow this instruction.
+Example configuration file (`config.toml`):
 
-    $ sudo apt-get install -y --no-install-recommends protobuf-compiler default-jdk maven
-    $ curl https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz | sudo tar Cxz /usr/local
-    $ export PATH=/usr/local/go/bin:$PATH
-    $ mkdir ~/gopath
-    $ export GOPATH=~/gopath
-
-
-### (Optional) Install Dependencies for MongoDB history storage
-    
-    $ sudo apt-get install -y --no-install-recommends mongodb
-
-### (Optional) Install Dependencies for FS inspector
-    
-    $ sudo apt-get install -y --no-install-recommends fuse
-
-### (Optional) Install Dependencies for pyearthquake
-    
-    $ sudo apt-get install -y --no-install-recommends python-{flask,scapy,zmq}
-    $ sudo pip install hexdump
-
-### (Optional) Install Dependencies for Ethernet inspector
-
-    $ sudo pip install hookswitch==0.0.2
-
-This should also install ryu.
-
-### (Optional) Install Dependencies for Ethernet inspector (ryu)
-#### Install Open vSwitch
-    
-    $ sudo apt-get install -y --no-install-recommends openvswitch-switch
-    
-Earthquake is tested with Open vSwitch 2.3.1 (Ubuntu 15.04).
-
-Note that Open vSwitch <= 2.0 is known *not* to work due to [a bug](http://git.openvswitch.org/cgi-bin/gitweb.cgi?p=openvswitch;a=commitdiff;h=cfa955b083c5617212a29a03423).
-
-    
-#### Install pipework
-    
-    $ sudo apt-get install -y --no-install-recommends arping
-    $ sudo curl https://raw.githubusercontent.com/jpetazzo/pipework/master/pipework -o /usr/local/bin/pipework
-    $ sudo chmod +x /usr/local/bin/pipework
-    
-
-#### Set up Open vSwitch
-	
-    $ sudo ovs-vsctl add-br ovsbr0
-    $ sudo ovs-vsctl set bridge ovsbr0 protocols=OpenFlow13
-    $ sudo ovs-vsctl set-controller ovsbr0 tcp:127.0.0.1:6633
-    $ sudo echo 'ip addr add 192.168.42.254/24 dev ovsbr0' > /etc/rc.local
-    $ sudo sh /etc/rc.local
-
-### (Optional) Install Dependencies for Ethernet inspector (nfqhook)
-    
-    $ sudo apt-get install -y --no-install-recommends libnetfilter-queue1 python-prctl
-    
-### Build Earthquake
-    
-    $ cd /path/to/earthquake
-    $ ./build
-    
+```toml
+explorePolicy = "random"
+[explorePolicyParam]
+  minInterval = 80
+  maxInterval = 3000
+  #shellActionInterval = 5000
+  #shellActionCommand = "echo hello $(date)"
+  #faultActionProbability = 0.0
+```

--- a/earthquake-container/cli/cli.go
+++ b/earthquake-container/cli/cli.go
@@ -17,22 +17,10 @@ package cli
 
 import (
 	"fmt"
-	"os"
-
 	log "github.com/cihub/seelog"
-	mcli "github.com/mitchellh/cli"
-	. "github.com/osrg/earthquake/earthquake/explorepolicy"
-	. "github.com/osrg/earthquake/earthquake/signal"
-	. "github.com/osrg/earthquake/earthquake/util/log"
+	eqcli "github.com/osrg/earthquake/earthquake/cli"
+	"os"
 )
-
-func CLIInit(debug bool) {
-	InitLog("", debug)
-	RegisterKnownSignals()
-	RegisterKnownExplorePolicies()
-}
-
-const EarthquakeVersion = "0.1.2"
 
 func recoverer(debug bool) {
 	if r := recover(); r != nil {
@@ -48,19 +36,22 @@ func recoverer(debug bool) {
 
 func CLIMain(args []string) int {
 	debug := os.Getenv("EQ_DEBUG") != ""
-	CLIInit(debug)
+	eqcli.CLIInit(debug)
 	defer recoverer(debug)
-	c := mcli.NewCLI(args[0], EarthquakeVersion)
-	c.Args = args[1:]
-	c.Commands = map[string]mcli.CommandFactory{
-		"init":       initCommandFactory,
-		"run":        runCommandFactory,
-		"tools":      toolsCommandFactory,
-		"inspectors": inspectorsCommandFactory,
+	if len(args) < 2 {
+		fmt.Printf("Usage: %s [OPTIONS] COMMAND [arg...]\n", args[0])
+		fmt.Printf("\n")
+		fmt.Printf("Docker Container + Earthquake Testing Framework\n")
+		fmt.Printf("\n")
+		fmt.Printf("Commands:\n")
+		fmt.Printf("\trun\tRun a command in a new container\n")
+		fmt.Printf("\n")
+		return 0
 	}
-	exitStatus, err := c.Run()
-	if err != nil {
-		fmt.Printf("failed to execute command: %s\n", err)
+	switch args[1] {
+	case "run":
+		return run(args[1:])
 	}
-	return exitStatus
+	fmt.Fprintf(os.Stderr, "'%s' is not a earthquake-container command.", args[1])
+	return 1
 }

--- a/earthquake-container/cli/prereq.go
+++ b/earthquake-container/cli/prereq.go
@@ -13,27 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+package cli
 
 import (
-	"flag"
-	logutil "github.com/osrg/earthquake/earthquake/util/log"
-	"github.com/osrg/hookfs/hookfs"
-	"os"
-	"testing"
+	"fmt"
+	cap "github.com/syndtr/gocapability/capability"
 )
 
-func TestMain(m *testing.M) {
-	flag.Parse()
-	logutil.InitLog("", true)
-	os.Exit(m.Run())
-}
-
-func TestInterfaceImpl(t *testing.T) {
-	h := &FilesystemInspector{}
-	func(x hookfs.HookWithInit) {}(h)
-	func(x hookfs.HookOnRead) {}(h)
-	func(x hookfs.HookOnMkdir) {}(h)
-	func(x hookfs.HookOnRmdir) {}(h)
-	func(x hookfs.HookOnOpenDir) {}(h)
+func checkPrerequisite() error {
+	c, err := cap.NewPid(0)
+	if err != nil {
+		return err
+	}
+	if !c.Get(cap.EFFECTIVE, cap.CAP_NET_ADMIN) {
+		return fmt.Errorf("CAP_NET_ADMIN is needed.")
+	}
+	if !c.Get(cap.EFFECTIVE, cap.CAP_SYS_ADMIN) {
+		return fmt.Errorf("CAP_SYS_ADMIN is needed.")
+	}
+	return nil
 }

--- a/earthquake-container/cli/run.go
+++ b/earthquake-container/cli/run.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	log "github.com/cihub/seelog"
+	flag "github.com/docker/docker/pkg/mflag"
+	dockerpty "github.com/fgrehm/go-dockerpty"
+	docker "github.com/fsouza/go-dockerclient"
+	. "github.com/osrg/earthquake/earthquake-container/container"
+	"os"
+	"time"
+)
+
+func parseRun(cmd *flag.FlagSet, args []string) (*docker.CreateContainerOptions, error) {
+	var (
+		flStdin  = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
+		flTty    = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
+		flDetach = cmd.Bool([]string{"d", "-detach"}, false, "[NOT SUPPORTED] Run container in background and print container ID")
+		flName   = cmd.String([]string{"-name"}, "", "Assign a name to the container")
+		// the caller should handle "-rm" with cmd.IsSet()
+		_ = cmd.Bool([]string{"-rm"}, false, "Automatically remove the container when it exits")
+		// the caller should handle "-eq-config"
+		flEqConfig = cmd.String([]string{"-eq-config"}, "", "Earthquake configuration file")
+	)
+	cmd.Require(flag.Min, 2)
+	if err := cmd.ParseFlags(args, true); err != nil {
+		return nil, err
+	}
+	if !*flStdin {
+		return nil, fmt.Errorf("-interactive is expected.")
+	}
+	if !*flTty {
+		return nil, fmt.Errorf("-tty is expected.")
+	}
+	if *flDetach {
+		return nil, fmt.Errorf("Currently, -detach is not supported.")
+	}
+	if *flEqConfig == "" {
+		return nil, fmt.Errorf("-eq-config is expected.")
+	}
+
+	image := cmd.Arg(0)
+	parsedArgs := cmd.Args()
+	execCmd := parsedArgs[1:]
+
+	dockerOpt := docker.CreateContainerOptions{
+		Name: *flName,
+		Config: &docker.Config{
+			Image:        image,
+			Cmd:          execCmd,
+			OpenStdin:    *flStdin,
+			StdinOnce:    true,
+			AttachStdin:  true,
+			AttachStdout: true,
+			AttachStderr: true,
+			Tty:          *flTty,
+		},
+		HostConfig: &docker.HostConfig{},
+	}
+	return &dockerOpt, nil
+}
+
+func bootContainer(client *docker.Client, opt *docker.CreateContainerOptions,
+	exitCh chan error) (*docker.Container, error) {
+	log.Debugf("Creating container for image %s", opt.Config.Image)
+	container, err := client.CreateContainer(*opt)
+	if err != nil {
+		return container, err
+	}
+
+	log.Debugf("Starting container %s", container.ID)
+	go func() {
+		exitCh <- dockerpty.Start(client, container, opt.HostConfig)
+	}()
+
+	trial := 0
+	for {
+		container, err = client.InspectContainer(container.ID)
+		if container.State.StartedAt.Unix() > 0 {
+			break
+		}
+		if trial > 30 {
+			return container, fmt.Errorf("container %s seems not started. state=%#v", container.ID, container.State)
+		}
+		trial += 1
+		time.Sleep(time.Duration(trial*100) * time.Millisecond)
+	}
+	log.Debugf("container state=%#v", container.State)
+	return container, nil
+}
+
+func removeContainer(client *docker.Client, container *docker.Container) error {
+	log.Debugf("Removing container %s", container.ID)
+	err := client.RemoveContainer(docker.RemoveContainerOptions{
+		ID:    container.ID,
+		Force: true,
+	})
+	log.Debugf("Removed container %s", container.ID)
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}
+
+func startRoutines(container *docker.Container, nfqueueNum int, configPath string) error {
+	log.Debugf("Configuring NFQUEUE %d for container %s", nfqueueNum, container.ID)
+	err := SetupNFQUEUE(container, nfqueueNum, false, false)
+	if err != nil {
+		return err
+	}
+
+	// TODO: refactor
+	log.Debugf("Starting Orchestrator")
+	go func() {
+		oerr := StartOrchestrator(configPath)
+		if oerr != nil {
+			panic(log.Critical(oerr))
+		}
+	}()
+
+	log.Debugf("Starting Inspector")
+	go func() {
+		ierr := StartEthernetInspector(container, nfqueueNum)
+		if ierr != nil {
+			panic(log.Critical(ierr))
+		}
+	}()
+
+	return nil
+}
+
+// FIXME: too long function scope
+func run(args []string) int {
+	if len(args) < 3 {
+		// FIXME
+		fmt.Fprintf(os.Stderr, "bad argument: %s\n", args)
+		return 1
+	}
+	flagSet := flag.NewFlagSet("run", flag.ExitOnError)
+	dockerOpt, err := parseRun(flagSet, args[1:])
+	removeOnExit := flagSet.IsSet("-rm")
+
+	nfqueueNum := 42 // FIXME
+	configPath := flagSet.Lookup("-eq-config").Value.String()
+
+	if err = checkPrerequisite(); err != nil {
+		fmt.Fprintf(os.Stderr, "prerequisite error: %s\n", err)
+		return 1
+	}
+
+	client, err := NewDockerClient()
+	if err != nil {
+		panic(err)
+	}
+
+	exited := make(chan error)
+	container, err := bootContainer(client, dockerOpt, exited)
+	if err == docker.ErrNoSuchImage {
+		log.Critical(err)
+		// TODO: pull the image automatically
+		log.Infof("You need to run `docker pull %s`", dockerOpt.Config.Image)
+		return 1
+	} else if err != nil {
+		panic(err)
+	}
+	if removeOnExit {
+		defer removeContainer(client, container)
+	}
+
+	err = startRoutines(container, nfqueueNum, configPath)
+	if err != nil {
+		panic(err)
+	}
+
+	err = <-exited
+	if err != nil {
+		log.Error(err)
+	}
+	log.Debugf("Exiting..")
+
+	return 0
+}

--- a/earthquake-container/container/util.go
+++ b/earthquake-container/container/util.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"fmt"
+	log "github.com/cihub/seelog"
+	docker "github.com/fsouza/go-dockerclient"
+	cliinsputil "github.com/osrg/earthquake/earthquake/cli/inspectors"
+	"github.com/osrg/earthquake/earthquake/inspector/ethernet"
+	"github.com/vishvananda/netns"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func NewDockerClient() (*docker.Client, error) {
+	host := os.Getenv("DOCKER_HOST")
+	hostIsLocal := host == "" || strings.HasPrefix(host, "unix://")
+	if !hostIsLocal {
+		log.Warnf("Detected DOCKER_HOST %s. This should not be remote.",
+			host)
+	}
+	return docker.NewClientFromEnv()
+}
+
+var origNs netns.NsHandle
+var newNs netns.NsHandle
+
+func enterDockerNetNs(container *docker.Container) error {
+	var err error
+	origNs, err = netns.Get()
+	if err != nil {
+		return log.Criticalf("could not obtain current netns. netns not supported?: %s", err)
+	}
+	// netns.GetFromDocker() does not work for recent dockers.
+	// So we use netns.GetFromPid() directly.
+	// https://github.com/vishvananda/netns/pull/10
+	newNs, err = netns.GetFromPid(container.State.Pid)
+	if err != nil {
+		return log.Criticalf("Could not get netns for container %s (pid=%d). The container has exited??: %s", container.ID, container.State.Pid, err)
+	}
+	runtime.LockOSThread()
+	netns.Set(newNs)
+	return nil
+}
+
+func leaveNetNs() {
+	netns.Set(origNs)
+	runtime.UnlockOSThread()
+	origNs.Close()
+	newNs.Close()
+}
+
+func SetupNFQUEUE(container *docker.Container, queueNum int, hookInput bool, disableBypass bool) error {
+	err := enterDockerNetNs(container)
+	if err != nil {
+		return err
+	}
+	defer leaveNetNs()
+
+	chain := "OUTPUT"
+	if hookInput {
+		chain = "INPUT"
+	}
+	iptArg := []string{"-A", chain, "-j", "NFQUEUE", "--queue-num", fmt.Sprintf("%d", queueNum)}
+	if !disableBypass {
+		iptArg = append(iptArg, "--queue-bypass")
+	}
+
+	log.Debugf("Running `iptables` with %s", iptArg)
+	cmd := exec.Command("iptables", iptArg...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func StartOrchestrator(path string) error {
+	// TODO: refactor. should not use cliinsputil.
+	autopilotOrchestrator, err := cliinsputil.NewAutopilotOrchestrator(path)
+	if err != nil {
+		return err
+	}
+	autopilotOrchestrator.Start()
+	return nil
+}
+
+func StartEthernetInspector(container *docker.Container, queueNum int) error {
+	err := enterDockerNetNs(container)
+	if err != nil {
+		return err
+	}
+	// FIXME: should not use REST RPC for in-process communication
+	insp := &ethernet.NFQInspector{
+		OrchestratorURL:  "http://localhost:10080/api/v3",
+		EntityID:         "_earthquake_ethernet_inspector",
+		NFQNumber:        uint16(queueNum),
+		EnableTCPWatcher: true,
+	}
+	defer leaveNetNs()
+	insp.Start()
+	return nil
+}

--- a/earthquake-container/main.go
+++ b/earthquake-container/main.go
@@ -13,27 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+package main
 
 import (
-	"flag"
-	logutil "github.com/osrg/earthquake/earthquake/util/log"
-	"github.com/osrg/hookfs/hookfs"
+	"github.com/osrg/earthquake/earthquake-container/cli"
 	"os"
-	"testing"
 )
 
-func TestMain(m *testing.M) {
-	flag.Parse()
-	logutil.InitLog("", true)
-	os.Exit(m.Run())
-}
-
-func TestInterfaceImpl(t *testing.T) {
-	h := &FilesystemInspector{}
-	func(x hookfs.HookWithInit) {}(h)
-	func(x hookfs.HookOnRead) {}(h)
-	func(x hookfs.HookOnMkdir) {}(h)
-	func(x hookfs.HookOnRmdir) {}(h)
-	func(x hookfs.HookOnOpenDir) {}(h)
+func main() {
+	os.Exit(cli.CLIMain(os.Args))
 }

--- a/earthquake/cli/inspectors.go
+++ b/earthquake/cli/inspectors.go
@@ -29,10 +29,11 @@ func (cmd inspectorsCmd) Help() string {
 	return `
 	Earthquake Inspectors
 	- fs: Filesystem inspector
+	- ethernet: Ethernet inspector
 
 	NOTE: this binary does NOT include following inspectors:
-	- Ethernet Inspector: (included in pyearthquake)
-	- Java Inspector:     (included in Java module net.osrg.earthquake)
+	- Java Inspector:     (included in earthquake/inspector/java)
+	- C Inspector:        (included in earthquake/inspector/c)
 	`
 }
 
@@ -40,7 +41,8 @@ func (cmd inspectorsCmd) Run(args []string) int {
 	c := mcli.NewCLI("earthquake inspectors", EarthquakeVersion)
 	c.Args = args
 	c.Commands = map[string]mcli.CommandFactory{
-		"fs": inspectors.FsCommandFactory,
+		"fs":       inspectors.FsCommandFactory,
+		"ethernet": inspectors.EtherCommandFactory,
 	}
 
 	exitStatus, err := c.Run()

--- a/earthquake/cli/inspectors/ethernet.go
+++ b/earthquake/cli/inspectors/ethernet.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspectors
+
+import (
+	"flag"
+
+	// "fmt"
+	log "github.com/cihub/seelog"
+	"github.com/mitchellh/cli"
+	inspector "github.com/osrg/earthquake/earthquake/inspector/ethernet"
+	//	restutil "github.com/osrg/earthquake/earthquake/util/rest"
+)
+
+type etherFlags struct {
+	AutopilotConfig   string
+	OrchestratorURL   string
+	EntityID          string
+	HookSwitchZMQAddr string
+	NFQNumber         int
+}
+
+var (
+	etherFlagset = flag.NewFlagSet("ethernet", flag.ExitOnError)
+	_etherFlags  = etherFlags{}
+)
+
+func init() {
+	etherFlagset.StringVar(&_etherFlags.OrchestratorURL, "orchestrator-url",
+		defaultOrchestratorURL, "orchestrator rest url")
+	etherFlagset.StringVar(&_etherFlags.EntityID, "entity-id",
+		"_earthquake_ethernet_inspector", "Entity ID")
+	etherFlagset.StringVar(&_etherFlags.HookSwitchZMQAddr, "hookswitch",
+		"ipc:///tmp/earthquake-container-hookswitch-zmq", "HookSwitch ZeroMQ addr")
+	etherFlagset.IntVar(&_etherFlags.NFQNumber, "nfq-number",
+		-1, "netfilter_queue number")
+	etherFlagset.StringVar(&_etherFlags.AutopilotConfig, "autopilot", "",
+		"start autopilot-mode orchestrator, if non-empty config path is set")
+}
+
+type etherCmd struct {
+}
+
+func (cmd etherCmd) Help() string {
+	return "Ethernet Inspector"
+}
+
+func (cmd etherCmd) Run(args []string) int {
+	return runEtherInspector(args)
+}
+
+func (cmd etherCmd) Synopsis() string {
+	return "Start Ethernet inspector"
+}
+
+func EtherCommandFactory() (cli.Command, error) {
+	return etherCmd{}, nil
+}
+
+func runEtherInspector(args []string) int {
+	if err := etherFlagset.Parse(args); err != nil {
+		log.Critical(err)
+		return 1
+	}
+
+	useHookSwitch := _etherFlags.NFQNumber < 0
+
+	if useHookSwitch && _etherFlags.HookSwitchZMQAddr == "" {
+		log.Critical("hookswitch is invalid")
+		return 1
+	}
+	if !useHookSwitch && _etherFlags.NFQNumber > 0xFFFF {
+		log.Critical("nfq-number is invalid")
+		return 1
+	}
+
+	if _etherFlags.AutopilotConfig != "" && _etherFlags.OrchestratorURL != defaultOrchestratorURL {
+		log.Critical("non-default orchestrator url set for autopilot orchestration mode")
+		return 1
+	}
+
+	if _etherFlags.AutopilotConfig != "" {
+		autopilotOrchestrator, err := NewAutopilotOrchestrator(_etherFlags.AutopilotConfig)
+		if err != nil {
+			panic(log.Critical(err))
+		}
+		log.Info("Starting autopilot-mode orchestrator")
+		go autopilotOrchestrator.Start()
+	}
+
+	var etherInspector inspector.EthernetInspector
+	if useHookSwitch {
+		etherInspector = &inspector.HookSwitchInspector{
+			OrchestratorURL:   _etherFlags.OrchestratorURL,
+			EntityID:          _etherFlags.EntityID,
+			HookSwitchZMQAddr: _etherFlags.HookSwitchZMQAddr,
+			EnableTCPWatcher:  true,
+		}
+	} else {
+		etherInspector = &inspector.NFQInspector{
+			OrchestratorURL:  _etherFlags.OrchestratorURL,
+			EntityID:         _etherFlags.EntityID,
+			NFQNumber:        uint16(_etherFlags.NFQNumber),
+			EnableTCPWatcher: true,
+		}
+	}
+
+	if err := etherInspector.Start(); err != nil {
+		panic(log.Critical(err))
+	}
+
+	// NOTREACHED
+	return 0
+}

--- a/earthquake/cli/inspectors/fs.go
+++ b/earthquake/cli/inspectors/fs.go
@@ -18,12 +18,11 @@ package inspectors
 import (
 	"flag"
 
-	"fmt"
+	//"fmt"
 	log "github.com/cihub/seelog"
 	"github.com/mitchellh/cli"
 	inspector "github.com/osrg/earthquake/earthquake/inspector/fs"
 	logutil "github.com/osrg/earthquake/earthquake/util/log"
-	restutil "github.com/osrg/earthquake/earthquake/util/rest"
 	"github.com/osrg/hookfs/hookfs"
 )
 
@@ -36,9 +35,8 @@ type fsFlags struct {
 }
 
 var (
-	fsFlagset              = flag.NewFlagSet("fs", flag.ExitOnError)
-	_fsFlags               = fsFlags{}
-	defaultOrchestratorURL = fmt.Sprintf("http://localhost:%d%s", restutil.DefaultPort, restutil.APIRoot)
+	fsFlagset = flag.NewFlagSet("fs", flag.ExitOnError)
+	_fsFlags  = fsFlags{}
 )
 
 func init() {
@@ -106,7 +104,7 @@ func runFsInspector(args []string) int {
 		go autopilotOrchestrator.Start()
 	}
 
-	hook := &inspector.EQFSHook{
+	hook := &inspector.FilesystemInspector{
 		OrchestratorURL: _fsFlags.OrchestratorURL,
 		EntityID:        _fsFlags.EntityID,
 	}

--- a/earthquake/cli/inspectors/util.go
+++ b/earthquake/cli/inspectors/util.go
@@ -16,11 +16,15 @@
 package inspectors
 
 import (
+	"fmt"
 	log "github.com/cihub/seelog"
 	. "github.com/osrg/earthquake/earthquake/explorepolicy"
 	. "github.com/osrg/earthquake/earthquake/orchestrator"
 	. "github.com/osrg/earthquake/earthquake/util/config"
+	restutil "github.com/osrg/earthquake/earthquake/util/rest"
 )
+
+var defaultOrchestratorURL = fmt.Sprintf("http://localhost:%d%s", restutil.DefaultPort, restutil.APIRoot)
 
 // instantiate new autopilot-mode orchestrator.
 //

--- a/earthquake/inspector/ethernet/ethernet_hookswitch.go
+++ b/earthquake/inspector/ethernet/ethernet_hookswitch.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethernet
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	log "github.com/cihub/seelog"
+	"github.com/google/gopacket/layers"
+	"github.com/osrg/earthquake/earthquake/inspector/ethernet/hookswitch"
+	"github.com/osrg/earthquake/earthquake/inspector/ethernet/tcpwatcher"
+	"github.com/osrg/earthquake/earthquake/signal"
+	restutil "github.com/osrg/earthquake/earthquake/util/rest"
+	zmq "github.com/vaughan0/go-zmq"
+)
+
+// TODO: support user-written MapPacketToEventFunc
+type HookSwitchInspector struct {
+	OrchestratorURL   string
+	EntityID          string
+	HookSwitchZMQAddr string
+	EnableTCPWatcher  bool
+	trans             *restutil.Transceiver
+	zmqChannels       *zmq.Channels
+	tcpWatcher        *tcpwatcher.TCPWatcher
+}
+
+func (this *HookSwitchInspector) Start() error {
+	log.Debugf("Initializing Ethernet Inspector %#v", this)
+	var err error
+
+	if this.EnableTCPWatcher {
+		this.tcpWatcher = tcpwatcher.New()
+	}
+
+	this.trans, err = restutil.NewTransceiver(this.OrchestratorURL, this.EntityID)
+	if err != nil {
+		return err
+	}
+	this.trans.Start()
+
+	zmqSocket, err := zmq.NewSocket(zmq.Pair)
+	if err != nil {
+		return err
+	}
+	zmqSocket.Bind(this.HookSwitchZMQAddr)
+	defer zmqSocket.Close()
+	this.zmqChannels = zmqSocket.Channels()
+	for {
+		select {
+		case msgBytes := <-this.zmqChannels.In():
+			meta, ethBytes, err := this.decodeZMQMessageBytes(msgBytes)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			eth, ip, tcp := parseEthernetBytes(ethBytes)
+			// note: tcpwatcher is not thread-safe
+			if this.EnableTCPWatcher && this.tcpWatcher.IsTCPRetrans(ip, tcp) {
+				meta.Op = hookswitch.Drop
+				err = this.sendZMQMessage(*meta, nil)
+				if err != nil {
+					log.Error(err)
+				}
+				continue
+			}
+			go func() {
+				if err := this.onHookSwitchMessage(*meta, eth, ip, tcp); err != nil {
+					log.Error(err)
+				}
+			}()
+		case err := <-this.zmqChannels.Errors():
+			return err
+		}
+	}
+	// NOTREACHED
+}
+
+func (this *HookSwitchInspector) decodeZMQMessageBytes(msgBytes [][]byte) (*hookswitch.HookSwitchMeta, []byte, error) {
+	if len(msgBytes) != 2 {
+		return nil, nil, fmt.Errorf("strange number of parts: %d", len(msgBytes))
+	}
+	meta := new(hookswitch.HookSwitchMeta)
+	eth := msgBytes[1]
+	if err := json.NewDecoder(bytes.NewReader(msgBytes[0])).Decode(meta); err != nil {
+		return nil, nil, err
+	}
+	return meta, eth, nil
+}
+
+func (this *HookSwitchInspector) onHookSwitchMessage(meta hookswitch.HookSwitchMeta,
+	eth *layers.Ethernet, ip *layers.IPv4, tcp *layers.TCP) error {
+	srcEntityID, dstEntityID := makeEntityIDs(eth, ip, tcp)
+	event, err := signal.NewPacketEvent(this.EntityID,
+		srcEntityID, dstEntityID, map[string]interface{}{})
+	if err != nil {
+		return err
+	}
+	actionCh, err := this.trans.SendEvent(event)
+	if err != nil {
+		return err
+	}
+	action := <-actionCh
+	switch action.(type) {
+	case *signal.EventAcceptanceAction:
+		meta.Op = hookswitch.Accept
+	case *signal.PacketFaultAction:
+		meta.Op = hookswitch.Drop
+	default:
+		return fmt.Errorf("unknown action %s", action)
+	}
+	// ignore original ethBytes, nil is enough
+	if err = this.sendZMQMessage(meta, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *HookSwitchInspector) sendZMQMessage(meta hookswitch.HookSwitchMeta, ethBytes []byte) error {
+	if !(meta.Op == hookswitch.Accept || meta.Op == hookswitch.Drop) {
+		return fmt.Errorf("bad opcode %s", meta.Op)
+	}
+	w := new(bytes.Buffer)
+	if err := json.NewEncoder(w).Encode(meta); err != nil {
+		return err
+	}
+	this.zmqChannels.Out() <- [][]byte{w.Bytes(), ethBytes}
+	return nil
+}

--- a/earthquake/inspector/ethernet/ethernet_nfq.go
+++ b/earthquake/inspector/ethernet/ethernet_nfq.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethernet
+
+import (
+	"fmt"
+	netfilter "github.com/AkihiroSuda/go-netfilter-queue"
+	log "github.com/cihub/seelog"
+	"github.com/google/gopacket/layers"
+	"github.com/osrg/earthquake/earthquake/inspector/ethernet/tcpwatcher"
+	"github.com/osrg/earthquake/earthquake/signal"
+	restutil "github.com/osrg/earthquake/earthquake/util/rest"
+)
+
+// TODO: support user-written MapPacketToEventFunc
+type NFQInspector struct {
+	OrchestratorURL  string
+	EntityID         string
+	NFQNumber        uint16
+	EnableTCPWatcher bool
+	trans            *restutil.Transceiver
+	tcpWatcher       *tcpwatcher.TCPWatcher
+}
+
+func (this *NFQInspector) Start() error {
+	log.Debugf("Initializing Ethernet Inspector %#v", this)
+	var err error
+
+	if this.EnableTCPWatcher {
+		this.tcpWatcher = tcpwatcher.New()
+	}
+
+	this.trans, err = restutil.NewTransceiver(this.OrchestratorURL, this.EntityID)
+	if err != nil {
+		return err
+	}
+	this.trans.Start()
+
+	nfq, err := netfilter.NewNFQueue(this.NFQNumber, 256, netfilter.NF_DEFAULT_PACKET_SIZE)
+	if err != nil {
+		return err
+	}
+	defer nfq.Close()
+	nfpChan := nfq.GetPackets()
+	for {
+		nfp := <-nfpChan
+		ip, tcp := this.decodeNFPacket(nfp)
+		// note: tcpwatcher is not thread-safe
+		if this.EnableTCPWatcher && this.tcpWatcher.IsTCPRetrans(ip, tcp) {
+			nfp.SetVerdict(netfilter.NF_DROP)
+			continue
+		}
+		go func() {
+			if err := this.onPacket(nfp, ip, tcp); err != nil {
+				log.Error(err)
+			}
+		}()
+	}
+	// NOTREACHED
+}
+
+func (this *NFQInspector) decodeNFPacket(nfp netfilter.NFPacket) (ip *layers.IPv4, tcp *layers.TCP) {
+	if layer := nfp.Packet.Layer(layers.LayerTypeIPv4); layer != nil {
+		ip, _ = layer.(*layers.IPv4)
+	}
+	if layer := nfp.Packet.Layer(layers.LayerTypeTCP); layer != nil {
+		tcp, _ = layer.(*layers.TCP)
+	}
+	return
+}
+
+func (this *NFQInspector) onPacket(nfp netfilter.NFPacket,
+	ip *layers.IPv4, tcp *layers.TCP) error {
+	srcEntityID, dstEntityID := makeEntityIDs(nil, ip, tcp)
+	event, err := signal.NewPacketEvent(this.EntityID,
+		srcEntityID, dstEntityID, map[string]interface{}{})
+	if err != nil {
+		return err
+	}
+	actionCh, err := this.trans.SendEvent(event)
+	if err != nil {
+		return err
+	}
+	action := <-actionCh
+	switch action.(type) {
+	case *signal.EventAcceptanceAction:
+		nfp.SetVerdict(netfilter.NF_ACCEPT)
+	case *signal.PacketFaultAction:
+		nfp.SetVerdict(netfilter.NF_DROP)
+	default:
+		return fmt.Errorf("unknown action %s", action)
+	}
+	return nil
+}

--- a/earthquake/inspector/ethernet/hookswitch/hookswitch.go
+++ b/earthquake/inspector/ethernet/hookswitch/hookswitch.go
@@ -13,27 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+// see https://github.com/osrg/hookswitch
+package hookswitch
 
-import (
-	"flag"
-	logutil "github.com/osrg/earthquake/earthquake/util/log"
-	"github.com/osrg/hookfs/hookfs"
-	"os"
-	"testing"
+type HookSwitchMeta struct {
+	// Ethernet frame ID
+	ID int `json:"id"`
+	// Op: {"accept", "drop", "modify"}
+	Op HookSwitchOp `json:"op"`
+}
+
+type HookSwitchOp string
+
+const (
+	Accept HookSwitchOp = "accept"
+	Drop   HookSwitchOp = "drop"
 )
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	logutil.InitLog("", true)
-	os.Exit(m.Run())
-}
-
-func TestInterfaceImpl(t *testing.T) {
-	h := &FilesystemInspector{}
-	func(x hookfs.HookWithInit) {}(h)
-	func(x hookfs.HookOnRead) {}(h)
-	func(x hookfs.HookOnMkdir) {}(h)
-	func(x hookfs.HookOnRmdir) {}(h)
-	func(x hookfs.HookOnOpenDir) {}(h)
-}

--- a/earthquake/inspector/ethernet/interface.go
+++ b/earthquake/inspector/ethernet/interface.go
@@ -13,27 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+package ethernet
 
-import (
-	"flag"
-	logutil "github.com/osrg/earthquake/earthquake/util/log"
-	"github.com/osrg/hookfs/hookfs"
-	"os"
-	"testing"
-)
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	logutil.InitLog("", true)
-	os.Exit(m.Run())
-}
-
-func TestInterfaceImpl(t *testing.T) {
-	h := &FilesystemInspector{}
-	func(x hookfs.HookWithInit) {}(h)
-	func(x hookfs.HookOnRead) {}(h)
-	func(x hookfs.HookOnMkdir) {}(h)
-	func(x hookfs.HookOnRmdir) {}(h)
-	func(x hookfs.HookOnOpenDir) {}(h)
+type EthernetInspector interface {
+	Start() error
 }

--- a/earthquake/inspector/ethernet/tcpwatcher/tcpwatcher.go
+++ b/earthquake/inspector/ethernet/tcpwatcher/tcpwatcher.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcpwatcher
+
+import (
+	"fmt"
+	"github.com/google/gopacket/layers"
+)
+
+// not thread-safe
+type TCPWatcher struct {
+	lastTCPMap map[string]layers.TCP
+}
+
+func New() *TCPWatcher {
+	return &TCPWatcher{
+		lastTCPMap: make(map[string]layers.TCP),
+	}
+}
+
+func (this *TCPWatcher) tcpMapKey(ip *layers.IPv4, tcp *layers.TCP) string {
+	return fmt.Sprintf("%s:%d-%s:%d", ip.SrcIP, tcp.SrcPort, ip.DstIP, tcp.DstPort)
+}
+
+func (this *TCPWatcher) isTCPRetrans0(ip *layers.IPv4, tcp *layers.TCP) bool {
+	k := this.tcpMapKey(ip, tcp)
+	lastTCP, ok := this.lastTCPMap[k]
+	if !ok {
+		return false
+	}
+	seqMatch := tcp.Seq == lastTCP.Seq
+	ackMatch := tcp.Ack == lastTCP.Ack
+	// we need any more bits?
+	bitsMatch := tcp.FIN == lastTCP.FIN &&
+		tcp.SYN == lastTCP.SYN &&
+		tcp.RST == lastTCP.RST &&
+		tcp.PSH == lastTCP.PSH &&
+		tcp.ACK == lastTCP.ACK
+	return seqMatch && ackMatch && bitsMatch
+}
+
+func (this *TCPWatcher) IsTCPRetrans(ip *layers.IPv4, tcp *layers.TCP) bool {
+	if tcp == nil {
+		return false
+	}
+	retrans := this.isTCPRetrans0(ip, tcp)
+	if !retrans {
+		k := this.tcpMapKey(ip, tcp)
+		if tcp.RST {
+			delete(this.lastTCPMap, k)
+		} else {
+			this.lastTCPMap[k] = *tcp
+		}
+	}
+	return retrans
+}

--- a/earthquake/inspector/ethernet/util.go
+++ b/earthquake/inspector/ethernet/util.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethernet
+
+import (
+	"fmt"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+func makeEntityIDs(eth *layers.Ethernet, ip *layers.IPv4, tcp *layers.TCP) (string, string) {
+	srcEntityID := "_earthquake_unknown_entity"
+	dstEntityID := "_earthquake_unknown_entity"
+	if ip != nil && tcp != nil {
+		srcEntityID = fmt.Sprintf("entity-%s:%d", ip.SrcIP, tcp.SrcPort)
+		dstEntityID = fmt.Sprintf("entity-%s:%d", ip.DstIP, tcp.DstPort)
+	}
+	return srcEntityID, dstEntityID
+}
+
+func parseEthernetBytes(b []byte) (eth *layers.Ethernet, ip *layers.IPv4, tcp *layers.TCP) {
+	packet := gopacket.NewPacket(b, layers.LayerTypeEthernet, gopacket.Default)
+	if layer := packet.Layer(layers.LayerTypeEthernet); layer != nil {
+		eth, _ = layer.(*layers.Ethernet)
+	}
+	if layer := packet.Layer(layers.LayerTypeIPv4); layer != nil {
+		ip, _ = layer.(*layers.IPv4)
+	}
+	if layer := packet.Layer(layers.LayerTypeTCP); layer != nil {
+		tcp, _ = layer.(*layers.TCP)
+	}
+	return
+}

--- a/earthquake/inspector/fs/fs.go
+++ b/earthquake/inspector/fs/fs.go
@@ -30,18 +30,18 @@ type EQFSHookContext struct {
 }
 
 // implements hookfs.Hook
-type EQFSHook struct {
+type FilesystemInspector struct {
 	OrchestratorURL string
 	EntityID        string
 	trans           *Transceiver
 }
 
-func (this *EQFSHook) String() string {
+func (this *FilesystemInspector) String() string {
 	return "EQFSHook"
 }
 
 // implements hookfs.HookWithInit
-func (this *EQFSHook) Init() error {
+func (this *FilesystemInspector) Init() error {
 	log.Debugf("Initializing FS Inspector %#v", this)
 	var err error
 	this.trans, err = NewTransceiver(this.OrchestratorURL, this.EntityID)
@@ -52,7 +52,7 @@ func (this *EQFSHook) Init() error {
 	return nil
 }
 
-func (this *EQFSHook) commonHook(op FilesystemOp, path string, m map[string]interface{}) (error, bool) {
+func (this *FilesystemInspector) commonHook(op FilesystemOp, path string, m map[string]interface{}) (error, bool) {
 	event, err := NewFilesystemEvent(this.EntityID, op, path, m)
 	if err != nil {
 		return err, false
@@ -77,14 +77,14 @@ func (this *EQFSHook) commonHook(op FilesystemOp, path string, m map[string]inte
 }
 
 // implements hookfs.HookOnRead
-func (this *EQFSHook) PreRead(path string, length int64, offset int64) ([]byte, error, bool, hookfs.HookContext) {
+func (this *FilesystemInspector) PreRead(path string, length int64, offset int64) ([]byte, error, bool, hookfs.HookContext) {
 	ctx := EQFSHookContext{Path: path}
 	log.Debugf("PreRead %s", ctx)
 	return nil, nil, false, ctx
 }
 
 // implements hookfs.HookOnRead
-func (this *EQFSHook) PostRead(realRetCode int32, realBuf []byte, ctx hookfs.HookContext) ([]byte, error, bool) {
+func (this *FilesystemInspector) PostRead(realRetCode int32, realBuf []byte, ctx hookfs.HookContext) ([]byte, error, bool) {
 	log.Debugf("PostRead %s", ctx)
 	path := (ctx.(EQFSHookContext)).Path
 	err, hooked := this.commonHook(PostRead, path, map[string]interface{}{})
@@ -100,14 +100,14 @@ func (this *EQFSHook) PostRead(realRetCode int32, realBuf []byte, ctx hookfs.Hoo
 }
 
 // implements hookfs.HookOnOpenDir
-func (this *EQFSHook) PreOpenDir(path string) (error, bool, hookfs.HookContext) {
+func (this *FilesystemInspector) PreOpenDir(path string) (error, bool, hookfs.HookContext) {
 	ctx := EQFSHookContext{Path: path}
 	log.Debugf("PreOpenDir %s", ctx)
 	return nil, false, ctx
 }
 
 // implements hookfs.HookOnOpenDir
-func (this *EQFSHook) PostOpenDir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+func (this *FilesystemInspector) PostOpenDir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	log.Debugf("PostOpenDir %s", ctx)
 	path := (ctx.(EQFSHookContext)).Path
 	err, hooked := this.commonHook(PostOpenDir, path, map[string]interface{}{})
@@ -123,7 +123,7 @@ func (this *EQFSHook) PostOpenDir(realRetCode int32, ctx hookfs.HookContext) (er
 }
 
 // implements hookfs.HookOnMkdir
-func (this *EQFSHook) PreMkdir(path string, mode uint32) (error, bool, hookfs.HookContext) {
+func (this *FilesystemInspector) PreMkdir(path string, mode uint32) (error, bool, hookfs.HookContext) {
 	ctx := EQFSHookContext{Path: path}
 	log.Debugf("PreMkdir %s", ctx)
 	err, hooked := this.commonHook(PreMkdir, path, map[string]interface{}{})
@@ -139,13 +139,13 @@ func (this *EQFSHook) PreMkdir(path string, mode uint32) (error, bool, hookfs.Ho
 }
 
 // implements hookfs.HookOnMkdir
-func (this *EQFSHook) PostMkdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+func (this *FilesystemInspector) PostMkdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	log.Debugf("PostMkdir %s", ctx)
 	return nil, false
 }
 
 // implements hookfs.HookOnRmdir
-func (this *EQFSHook) PreRmdir(path string) (error, bool, hookfs.HookContext) {
+func (this *FilesystemInspector) PreRmdir(path string) (error, bool, hookfs.HookContext) {
 	ctx := EQFSHookContext{Path: path}
 	log.Debugf("PreMkdir %s", ctx)
 	err, hooked := this.commonHook(PreRmdir, path, map[string]interface{}{})
@@ -161,7 +161,7 @@ func (this *EQFSHook) PreRmdir(path string) (error, bool, hookfs.HookContext) {
 }
 
 // implements hookfs.HookOnRmdir
-func (this *EQFSHook) PostRmdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+func (this *FilesystemInspector) PostRmdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	log.Debugf("PostRmdir %s", ctx)
 	return nil, false
 }

--- a/earthquake/orchestrator/orchestrator.go
+++ b/earthquake/orchestrator/orchestrator.go
@@ -13,6 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+  Orchestrator manages inspectorhandlers, entities, and the policy.
+
+  Event:  inspector  --RPC-->  inspectorhandler -> entity -> orchestrator -> policy
+  Action: inspector <--RPC--   inspectorhandler <- entity <- orchestrator <- policy
+
+*/
 package orchestrator
 
 import (

--- a/earthquake/signal/event_packet.go
+++ b/earthquake/signal/event_packet.go
@@ -15,9 +15,30 @@
 
 package signal
 
+import "github.com/satori/go.uuid"
+
 // implements Event
 type PacketEvent struct {
 	BasicEvent
+}
+
+func NewPacketEvent(entityID, srcEntityID, dstEntityID string, m map[string]interface{}) (Event, error) {
+	action := &PacketEvent{}
+	action.InitSignal()
+	action.SetID(uuid.NewV4().String())
+	action.SetEntityID(entityID)
+	action.SetType("event")
+	action.SetClass("PacketEvent")
+	action.SetDeferred(true)
+	opt := map[string]interface{}{
+		"src_entity": srcEntityID,
+		"dst_entity": dstEntityID,
+	}
+	for k, v := range m {
+		opt[k] = v
+	}
+	action.SetOption(opt)
+	return action, nil
 }
 
 // implements Event

--- a/example/etcd/3517-reproduce/config.toml
+++ b/example/etcd/3517-reproduce/config.toml
@@ -7,6 +7,7 @@ explorePolicy = "random"
 notCleanIfValidationFail= "true"
 
 [explorePolicyParam]
- minInterval = 5
+ minInterval = 100
+ maxInterval = 1000
 
 # storageType = "mongodb"

--- a/example/etcd/3517-reproduce/materials/validate.sh
+++ b/example/etcd/3517-reproduce/materials/validate.sh
@@ -3,7 +3,7 @@
 
 export ETCDCTL_PEERS=http://192.168.42.1:4001,http://192.168.42.2:4001,http://192.168.42.3:4001
 echo "getting key"
-$EQ_MATERIALS_DIR/etcd_testbed/etcd/bin/etcdctl --no-sync --timeout 10s get /k
+$EQ_MATERIALS_DIR/etcd_testbed/etcd/bin/etcdctl --no-sync --timeout 10s get /k1
 result=$?
 echo "result: $result"
 

--- a/example/template/mypolicy.go
+++ b/example/template/mypolicy.go
@@ -46,6 +46,8 @@ func (p *MyPolicy) QueueNextEvent(event signal.Event) {
 		panic(err)
 	}
 	// send in a goroutine so as to make the function non-blocking.
+	// (Note that earthquake/util/queue/TimeBoundedQueue provides
+	// better semantics and determinism, this is just an example.)
 	go func() {
 		fmt.Printf("Action ready: %s\n", action)
 		p.nextActionChan <- action

--- a/example/zk-repro-2251.nfqhook/README.md
+++ b/example/zk-repro-2251.nfqhook/README.md
@@ -1,0 +1,14 @@
+# ZooKeeper Bug [ZOOKEEPER-2251](https://issues.apache.org/jira/browse/ZOOKEEPER-2251): Client gets hanged
+
+
+## How to Reproduce the Bug with Earthquake
+
+This directory does not include a reproduction script for ZOOKEEPER-2251 yet.
+
+    $ docker run -it ubuntu:14.04
+    docker$ apt-get update && apt-get install zookeeper # tested with 3.4.5
+	docker$ PATH=/usr/share/zookeeper/bin:$PATH
+	docker$ zkServer.sh start
+	docker$ SETUP_EARTHQUAKE # to be documented. Dumb exploration policy is enough.
+    docker$ for f in $(seq 1 1000); do zkCli.sh ls /; done
+

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -5,6 +5,6 @@ title = "Earthquake"
 theme = "bootie-docs-custom"
 copyright = "Copyright© 2015 Nippon Telegraph and Telephone Corporation"
 [params]
-  description = "A framework of implementation level distributed system model checkers"
+  description = "A programmable fuzzy scheduler for testing distributed systems"
   mainMenu = ["about", "gettingStarted", "categories/blog"]
   repositoryUrl = "https://github.com/osrg/earthquake/"

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -22,6 +22,7 @@ but we believe that one of the most important reasons is lacking of a good debug
 * ZooKeeper:
  * Found [ZOOKEEPER-2212](https://issues.apache.org/jira/browse/ZOOKEEPER-2212) (race): [(blog article)]({{< relref "post/zookeeper-2212.md" >}})
  * Reproduced [ZOOKEEPER-2080](https://issues.apache.org/jira/browse/ZOOKEEPER-2080) (race): [(blog article)]({{< relref "post/zookeeper-2080.md" >}})
+ * Reproduced [ZOOKEEPER-2251](https://issues.apache.org/jira/browse/ZOOKEEPER-2251) (race): To Be Documented
 
 * Etcd:
  * Found an etcd command line client (etcdctl) bug [#3517](https://github.com/coreos/etcd/issues/3517) (timing specification), fixed in [#3530](https://github.com/coreos/etcd/pull/3530). The fix also resulted a hint of [#3611](https://github.com/coreos/etcd/issues/3611): To Be Documented

--- a/hugo/content/about.md
+++ b/hugo/content/about.md
@@ -1,6 +1,6 @@
 +++
 categories = ["general"]
-date = "2015-07-22T14:18:43+09:00"
+date = "2015-12-14"
 tags = ["document"]
 title = "About Earthquake"
 
@@ -21,7 +21,7 @@ They showed the existence of the bugs by building implementation level distribut
 The DMCKs have a capability of searching complex state space of protocols and injeting faults at critical timings.
 In addition, they can work with actual implementation (not formal model [\[2\]][2]) directly.
 
-earthquake is a framework for such DMCKs.
+earthquake is a programmable fuzz testing framework inspired by such DMCKs.
 Its design does not depend on programming languages and opearting systems.
 You can write your own state space search policy for your system.
 We hope it will make your life a little bit easier.

--- a/hugo/content/gettingStarted.md
+++ b/hugo/content/gettingStarted.md
@@ -1,44 +1,24 @@
 +++
 categories = ["general"]
-date = "2015-08-20"
+date = "2015-12-15"
 tags = ["document"]
 title = "Getting Started"
 
 +++
-All you have to do is make Docker installed on your host and run the pre-built Docker image [osrg/earthquake](https://registry.hub.docker.com/u/osrg/earthquake/).
+For full-stack environment, please refer to [how-to-setup-env-full.md](https://github.com/osrg/earthquake/blob/master/doc/how-to-setup-env-full.md).
 
-[![Docker Hub](http://dockeri.co/image/osrg/earthquake)](https://registry.hub.docker.com/u/osrg/earthquake/)
+    $ sudo apt-get install libzmq3-dev libnetfilter-queue-dev
+    $ go get github.com/osrg/earthquake/earthquake-container
+    $ sudo earthquake-container run -it --rm --eq-config config.toml ubuntu bash
 
+Example configuration file (`config.toml`):
+
+
+    explorePolicy = "random"
+    [explorePolicyParam]
+      minInterval = 80
+      maxInterval = 3000
+      #shellActionInterval = 5000
+      #shellActionCommand = "echo hello $(date)"
+      #faultActionProbability = 0.0
     
-    $ docker run --rm --tty --interactive osrg/earthquake
-	INIT: Running without privileged mode. Please set EQ_DOCKER_PRIVILEGED if you want to use Ethernet Inspector
-	INIT: Earthquake is installed on /earthquake. Please refer to /earthquake/README.md
-	INIT: Starting command: ['/bin/bash', '--login', '-i']
-	root@a0c2e4413483:/earthquake# ^D
-	INIT: Exiting with status 0..(['/bin/bash', '--login', '-i'])
-	
-Then, you can do the things what you want in `/earthquake` directory.
-You might want to try several [examples](https://github.com/osrg/earthquake/blob/master/example).
-
-
-## Privileged Mode (provides Docker-in-Docker, Open vSwitch, and Ryu)
-This mode might be useful for Ethernet Inspector.
-    
-    $ sudo modprobe openvswitch
-    $ docker run --rm --tty --interactive --privileged -e EQ_DOCKER_PRIVILEGED=1 osrg/earthquake 
-    INIT: Running with privileged mode. Enabling DinD, OVS, and Ryu
-    INIT: Earthquake is installed on /earthquake. Please refer to /earthquake/README.md
-    INIT: Starting command: ['wrapdocker', '/init.dind-ovs-ryu.sh']
-    * /etc/openvswitch/conf.db does not exist
-    * Creating empty database /etc/openvswitch/conf.db
-    * Starting ovsdb-server
-    * Configuring Open vSwitch system IDs
-    * Starting ovs-vswitchd
-    * Enabling remote OVSDB managers
-    Assigned 192.168.42.254 to ovsbr0
-    root@907529be8b21:/earthquake# ^D
-	INIT: Exiting with status 0..(['wrapdocker', '/init.dind-ovs-ryu.sh'])
-
-
-[README file](https://github.com/osrg/earthquake/blob/master/README.md) and [this article]({{< relref "post/zookeeper-2212.md" >}}) are also good start points.
-


### PR DESCRIPTION
Usage: $ sudo earthquake-container run -it --rm --eq-config config.toml ubuntu bash
  
TODO:

* Embed default configuration file
* Support filesystem inspector for Docker volumes (-v)
* Eliminate RPCs for in-process communication
* Support dynamic reloading of explorePolicyParam
* Exposes some stastics via REST (plus web ui?)
* docs and tests
