### PR TITLE
inspector/ethernet: include packet []byte in PacketEvent

### DIFF
--- a/earthquake/inspector/ethernet/ethernet_hookswitch.go
+++ b/earthquake/inspector/ethernet/ethernet_hookswitch.go
@@ -93,7 +93,7 @@ func (this *HookSwitchInspector) Serve() error {
 				continue
 			}
 			go func() {
-				if err := this.onHookSwitchMessage(*meta, eth, ip, tcp); err != nil {
+				if err := this.onHookSwitchMessage(*meta, ethBytes, eth, ip, tcp); err != nil {
 					log.Error(err)
 				}
 			}()
@@ -123,10 +123,13 @@ func (this *HookSwitchInspector) decodeZMQMessageBytes(msgBytes [][]byte) (*hook
 }
 
 func (this *HookSwitchInspector) onHookSwitchMessage(meta hookswitch.HookSwitchMeta,
+	bytes []byte,
 	eth *layers.Ethernet, ip *layers.IPv4, tcp *layers.TCP) error {
 	srcEntityID, dstEntityID := makeEntityIDs(eth, ip, tcp)
 	event, err := signal.NewPacketEvent(this.EntityID,
-		srcEntityID, dstEntityID, map[string]interface{}{})
+		srcEntityID, dstEntityID, map[string]interface{}{
+			"bytes": bytes,
+		})
 	if err != nil {
 		return err
 	}

--- a/earthquake/inspector/ethernet/ethernet_nfq.go
+++ b/earthquake/inspector/ethernet/ethernet_nfq.go
@@ -84,11 +84,23 @@ func (this *NFQInspector) decodeNFPacket(nfp netfilter.NFPacket) (ip *layers.IPv
 	return
 }
 
+func packetBytes(nfp netfilter.NFPacket) []byte {
+	dummyEth := []byte("\xff\xff\xff\xff\xff\xff" +
+		"\x00\x00\x00\x00\x00\x00" +
+		"\x08\x00")
+	payload := nfp.Packet.Data()
+	return append(dummyEth[:], payload[:]...)
+}
+
 func (this *NFQInspector) onPacket(nfp netfilter.NFPacket,
 	ip *layers.IPv4, tcp *layers.TCP) error {
 	srcEntityID, dstEntityID := makeEntityIDs(nil, ip, tcp)
+	bytes := packetBytes(nfp)
 	event, err := signal.NewPacketEvent(this.EntityID,
-		srcEntityID, dstEntityID, map[string]interface{}{})
+		srcEntityID, dstEntityID,
+		map[string]interface{}{
+			"bytes": bytes,
+		})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now the packet bytes (type of []byte) are available as `packetEvent.JSONMap()["option"]["bytes"]`.

Fix #111