### PR TITLE
cli: fix typo

### DIFF
--- a/earthquake/cli/inspectors/proc.go
+++ b/earthquake/cli/inspectors/proc.go
@@ -68,7 +68,7 @@ func (cmd procCmd) Run(args []string) int {
 		return 1
 	}
 
-	autopilot, err := conditionalStartAutopilotOrchestrator(_fsFlags.commonFlags)
+	autopilot, err := conditionalStartAutopilotOrchestrator(_procFlags.commonFlags)
 	if err != nil {
 		log.Critical(err)
 		return 1


### PR DESCRIPTION
typo was introduced in this commit (Mar 31)
https://github.com/osrg/earthquake/commit/b2b639dd3ff55861616e69634b795892cbf2055f